### PR TITLE
Fix issue with stash contract version detection

### DIFF
--- a/abis/ExtraRewardStashV30.json
+++ b/abis/ExtraRewardStashV30.json
@@ -1,0 +1,114 @@
+[
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
+      { "internalType": "address", "name": "_operator", "type": "address" },
+      { "internalType": "address", "name": "_staker", "type": "address" },
+      { "internalType": "address", "name": "_gauge", "type": "address" },
+      { "internalType": "address", "name": "_rFactory", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "claimRewards",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "crv",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gauge",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getName",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hasRedirected",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "historicalRewards",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "operator",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pid",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "processStash",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardFactory",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "staker",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stashRewards",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokenCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "tokenInfo",
+    "outputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "address", "name": "rewardAddress", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -6,6 +6,7 @@ export const BIG_DECIMAL_1E18 = BigDecimal.fromString('1e18')
 export const BIG_DECIMAL_ZERO = BigDecimal.fromString('0')
 export const BIG_DECIMAL_ONE = BigDecimal.fromString('1')
 
+export const BIG_INT_MINUS_ONE = BigInt.fromI32(-1)
 export const BIG_INT_ZERO = BigInt.fromString('0')
 export const BIG_INT_ONE = BigInt.fromString('1')
 

--- a/subgraphs/curve-pools/schema.graphql
+++ b/subgraphs/curve-pools/schema.graphql
@@ -1,15 +1,15 @@
 type Deposit @entity {
   id: ID!
-  user: Bytes! # address
-  poolid: BigInt! # uint256
+  user: User! # address
+  poolid: Pool! 
   amount: BigInt! # uint256
   timestamp: BigInt!
 }
 
 type Withdrawal @entity {
   id: ID!
-  user: Bytes! # address
-  poolid: BigInt! # uint256
+  user: User! # address
+  poolid: Pool!
   amount: BigInt! # uint256
   timestamp: BigInt!
 }
@@ -18,13 +18,13 @@ type Withdrawal @entity {
 type User @entity {
   id: ID!
   address: Bytes!
-  withdrawals: [Withdrawal!] @derivedfrom(field: user)
-  deposits: [Deposit!] @derivedfrom(field: user)
+  withdrawals: [Withdrawal!] @derivedFrom(field: "user")
+  deposits: [Deposit!] @derivedFrom(field: "user")
 }
 
 type ExtraReward @entity {
   id: ID!
-  poolid: BigInt!
+  poolid: Pool!
   contract: Bytes! #address
   token: Bytes! #address
 }
@@ -49,21 +49,23 @@ type Pool @entity {
   cvxApr: BigDecimal!
   extraRewardsApr: BigDecimal!
   baseApr: BigDecimal!
-  deposits: [Deposit!] @derivedfrom(field: poolid)
-  withdrawals: [Withdrawal!] @derivedfrom(field: poolid)
+  " TODO: set up relations "
+  deposits: [Deposit!] @derivedFrom(field: "poolid")
+  withdrawals: [Withdrawal!] @derivedFrom(field: "poolid")
   " Curve swap pool "
   swap: Bytes! #address
   " Underlying asset type (USD, BTC...) "
   assetType: Int!
   " Extra reward contracts "
   extras: [String!]!
+  extraRewards: [ExtraReward!] @derivedFrom(field: "poolid")
   coins: [Bytes!]! #address
-  snapshots: [DailyPoolSnapshot!] @derivedfrom(field: poolid)
+  snapshots: [DailyPoolSnapshot!] @derivedFrom(field: "poolid")
 }
 
 type DailyPoolSnapshot @entity {
   id: ID!
-  poolid: BigInt!
+  poolid: Pool!
   poolName: String!
   withdrawalCount: BigInt!
   depositCount: BigInt!

--- a/subgraphs/curve-pools/src/mapping.ts
+++ b/subgraphs/curve-pools/src/mapping.ts
@@ -16,11 +16,11 @@ import {
 import {
   ADDRESS_ZERO,
   ASSET_TYPES,
-  BIG_DECIMAL_1E18,
+  BIG_DECIMAL_1E18, BIG_INT_MINUS_ONE,
   BIG_INT_ONE,
   BIG_INT_ZERO,
   BOOSTER_ADDRESS,
-  CURVE_REGISTRY,
+  CURVE_REGISTRY
 } from 'const'
 import { CurveRegistry } from '../generated/Booster/CurveRegistry'
 import { ERC20 } from '../generated/Booster/ERC20'
@@ -73,6 +73,8 @@ export function handleAddPool(call: AddPoolCall): void {
   pool.assetType = ASSET_TYPES.has(swap.toHexString()) ? ASSET_TYPES.get(swap.toHexString()) : 0
   pool.gauge = call.inputs._gauge
   pool.stashVersion = call.inputs._stashVersion
+  // Initialize minor version at -1
+  pool.stashMinorVersion = BIG_INT_MINUS_ONE
   // If there is a stash contract, get the reward tokens
   if (stash != ADDRESS_ZERO) {
     getPoolExtras(pool)
@@ -91,7 +93,7 @@ export function handleShutdownPool(call: ShutdownPoolCall): void {
 
 export function handleWithdrawn(event: WithdrawnEvent): void {
   const withdrawal = new Withdrawal(event.transaction.hash.toHex() + '-' + event.logIndex.toString())
-  withdrawal.user = event.params.user
+  withdrawal.user = event.params.user.toHexString()
   withdrawal.poolid = event.params.poolid
   withdrawal.amount = event.params.amount
   withdrawal.timestamp = event.block.timestamp
@@ -139,7 +141,7 @@ export function handleWithdrawn(event: WithdrawnEvent): void {
 
 export function handleDeposited(event: DepositedEvent): void {
   const deposit = new Deposit(event.transaction.hash.toHex() + '-' + event.logIndex.toString())
-  deposit.user = event.params.user
+  deposit.user = event.params.user.toHexString()
   deposit.poolid = event.params.poolid
   deposit.amount = event.params.amount
   deposit.timestamp = event.block.timestamp

--- a/subgraphs/curve-pools/subgraph.yaml
+++ b/subgraphs/curve-pools/subgraph.yaml
@@ -34,8 +34,8 @@ dataSources:
           file: ../../abis/CLAggregator.json
         - name: CurvePool
           file: ../../abis/CurvePool.json
-        - name: ExtraRewardStashV31
-          file: ../../abis/ExtraRewardStashV31.json
+        - name: ExtraRewardStashV30
+          file: ../../abis/ExtraRewardStashV30.json
         - name: ExtraRewardStashV32
           file: ../../abis/ExtraRewardStashV32.json
         - name: ExtraRewardStashV2

--- a/subgraphs/locker/schema.graphql
+++ b/subgraphs/locker/schema.graphql
@@ -9,9 +9,9 @@ type Token @entity {
 type User @entity {
   id: ID!
   address: Bytes!
-  rewards: [Reward!] @derivedfrom(field: user)
-  locks: [Lock!] @derivedfrom(field: user)
-  withdrawals: [Withdrawal!] @derivedfrom(field: user)
+  receivedRewards: [ReceivedReward!] @derivedFrom(field: "user")
+  locks: [Lock!] @derivedFrom(field: "user")
+  withdrawals: [Withdrawal!] @derivedFrom(field: "user")
   totalLocked: BigInt!
   totalLockedUSD: BigDecimal!
 }
@@ -33,9 +33,18 @@ type Withdrawal @entity {
   time: BigInt!
 }
 
-type Reward @entity {
+type ReceivedReward @entity {
   id: ID!
   user: User!
+  token: Token!
+  kickReward: Boolean!
+  amount: BigInt!
+  amountUSD: BigDecimal!
+  time: BigInt!
+}
+
+type AddedReward @entity {
+  id: ID!
   token: Token!
   amount: BigInt!
   amountUSD: BigDecimal!

--- a/subgraphs/locker/subgraph.yaml
+++ b/subgraphs/locker/subgraph.yaml
@@ -42,4 +42,6 @@ dataSources:
           handler: handleStaked
         - event: Withdrawn(indexed address,uint256,bool)
           handler: handleWithdrawn
+        - event: RewardAdded(indexed address,uint256)
+          handler: handleRewardAdded
       file: ./src/mapping.ts


### PR DESCRIPTION
Minor version inference was mixing up v3 and v3.1 contracts. Now handle v3, v3.1 and v3.2 (the latter two having the same ABI)