### PR TITLE
fix: set token

### DIFF
--- a/subgraphs/curve-pools/src/mapping.ts
+++ b/subgraphs/curve-pools/src/mapping.ts
@@ -43,12 +43,6 @@ export function handleAddPool(call: AddPoolCall): void {
   const pool = new Pool(pid.toString())
   let stash = ADDRESS_ZERO
   if (!poolInfo.reverted) {
-    // 0 - lptoken
-    // 1 - token
-    // 2 - gauge
-    // 3 - crvRewards
-    // 4 - stash
-    // 5 - shutdown
     pool.token = poolInfo.value.value1
 
     pool.crvRewardsPool = poolInfo.value.value3

--- a/subgraphs/curve-pools/src/mapping.ts
+++ b/subgraphs/curve-pools/src/mapping.ts
@@ -43,6 +43,14 @@ export function handleAddPool(call: AddPoolCall): void {
   const pool = new Pool(pid.toString())
   let stash = ADDRESS_ZERO
   if (!poolInfo.reverted) {
+    // 0 - lptoken
+    // 1 - token
+    // 2 - gauge
+    // 3 - crvRewards
+    // 4 - stash
+    // 5 - shutdown
+    pool.token = poolInfo.value.value1
+
     pool.crvRewardsPool = poolInfo.value.value3
     const context = new DataSourceContext()
     context.setString('pid', pid.toString())


### PR DESCRIPTION
I just realized that `token` is always `ZERO`. This PR fixes this.

Should more fields initialized from `poolInfo`? `lpToken` and `gauge` are coming from the event input - these are available in `poolInfo` as well. Maybe set `pool.active = !poolInfo.shutdown`?

My changes are **untested**.