### PR TITLE
Fix/apy

### DIFF
--- a/abis/Booster.json
+++ b/abis/Booster.json
@@ -1,0 +1,461 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_staker", "type": "address" },
+      { "internalType": "address", "name": "_minter", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "poolid", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Deposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "poolid", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Withdrawn",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "FEE_DENOMINATOR",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MaxFees",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_lptoken", "type": "address" },
+      { "internalType": "address", "name": "_gauge", "type": "address" },
+      { "internalType": "uint256", "name": "_stashVersion", "type": "uint256" }
+    ],
+    "name": "addPool",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
+      { "internalType": "address", "name": "_gauge", "type": "address" }
+    ],
+    "name": "claimRewards",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "crv",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "bool", "name": "_stake", "type": "bool" }
+    ],
+    "name": "deposit",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
+      { "internalType": "bool", "name": "_stake", "type": "bool" }
+    ],
+    "name": "depositAll",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "distributionAddressId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "earmarkFees",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "earmarkIncentive",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_pid", "type": "uint256" }],
+    "name": "earmarkRewards",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeDistro",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeManager",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeToken",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "gaugeMap",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isShutdown",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lockFees",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lockIncentive",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lockRewards",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minter",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "platformFee",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "poolInfo",
+    "outputs": [
+      { "internalType": "address", "name": "lptoken", "type": "address" },
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "address", "name": "gauge", "type": "address" },
+      { "internalType": "address", "name": "crvRewards", "type": "address" },
+      { "internalType": "address", "name": "stash", "type": "address" },
+      { "internalType": "bool", "name": "shutdown", "type": "bool" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolLength",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolManager",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "registry",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardArbitrator",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
+      { "internalType": "address", "name": "_address", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+    ],
+    "name": "rewardClaimed",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardFactory",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_arb", "type": "address" }],
+    "name": "setArbitrator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_rfactory", "type": "address" },
+      { "internalType": "address", "name": "_sfactory", "type": "address" },
+      { "internalType": "address", "name": "_tfactory", "type": "address" }
+    ],
+    "name": "setFactories",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "inputs": [], "name": "setFeeInfo", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "address", "name": "_feeM", "type": "address" }],
+    "name": "setFeeManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_lockFees", "type": "uint256" },
+      { "internalType": "uint256", "name": "_stakerFees", "type": "uint256" },
+      { "internalType": "uint256", "name": "_callerFees", "type": "uint256" },
+      { "internalType": "uint256", "name": "_platform", "type": "uint256" }
+    ],
+    "name": "setFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_pid", "type": "uint256" }],
+    "name": "setGaugeRedirect",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_owner", "type": "address" }],
+    "name": "setOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_poolM", "type": "address" }],
+    "name": "setPoolManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_rewards", "type": "address" },
+      { "internalType": "address", "name": "_stakerRewards", "type": "address" }
+    ],
+    "name": "setRewardContracts",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_treasury", "type": "address" }],
+    "name": "setTreasury",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "_voteDelegate", "type": "address" }],
+    "name": "setVoteDelegate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_pid", "type": "uint256" }],
+    "name": "shutdownPool",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "inputs": [], "name": "shutdownSystem", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "staker",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakerIncentive",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakerRewards",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stashFactory",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokenFactory",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasury",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_voteId", "type": "uint256" },
+      { "internalType": "address", "name": "_votingAddress", "type": "address" },
+      { "internalType": "bool", "name": "_support", "type": "bool" }
+    ],
+    "name": "vote",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "voteDelegate",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address[]", "name": "_gauge", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "_weight", "type": "uint256[]" }
+    ],
+    "name": "voteGaugeWeight",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "voteOwnership",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "voteParameter",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+    ],
+    "name": "withdraw",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_pid", "type": "uint256" }],
+    "name": "withdrawAll",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "address", "name": "_to", "type": "address" }
+    ],
+    "name": "withdrawTo",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -17,7 +17,6 @@ export const BIG_INT_ONE = BigInt.fromString('1')
 export const BIG_INT_1E18 = BigInt.fromString('1000000000000000000')
 
 export const SECONDS_PER_YEAR = BigDecimal.fromString('31536000')
-export const T_TOKEN = '0xcdf7028ceab81fa0c6971208e83fa7872994bee5'
 export const RKP3R_TOKEN = '0xEdB67Ee1B171c4eC66E6c10EC43EDBbA20FaE8e9'
 export const RKP3R_ADDRESS = Address.fromString(RKP3R_TOKEN)
 export const CVX_TOKEN = '0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B'
@@ -69,7 +68,7 @@ FOREX_ORACLES.set(GBP_LP_TOKEN, Address.fromString('0x5c0Ab2d9b5a7ed9f470386e82B
 FOREX_ORACLES.set(AUD_LP_TOKEN, Address.fromString('0x77F9710E7d0A19669A13c055F62cd80d313dF022'))
 FOREX_ORACLES.set(CHF_LP_TOKEN, Address.fromString('0x449d117117838fFA61263B61dA6301AA2a88B13A'))
 
-// handle tokens that only only trade on Curve
+// handle tokens that only trade on Curve
 // maps to other token on curve pool that can be priced elswhere
 // and token indice to know whether to invert price oracle or not
 class OracleInfo {
@@ -80,6 +79,7 @@ class OracleInfo {
     this.tokenIndex = tokenIndex
   }
 }
+export const T_TOKEN = '0xcdf7028ceab81fa0c6971208e83fa7872994bee5'
 export const CURVE_ONLY_TOKENS = new Map<string, OracleInfo>()
 CURVE_ONLY_TOKENS.set(CVXFXS_TOKEN, new OracleInfo(Address.fromString(FXS_TOKEN), 1))
 CURVE_ONLY_TOKENS.set(T_TOKEN, new OracleInfo(WETH_ADDRESS, 1))

--- a/packages/constants/index.ts
+++ b/packages/constants/index.ts
@@ -17,7 +17,7 @@ export const BIG_INT_ONE = BigInt.fromString('1')
 export const BIG_INT_1E18 = BigInt.fromString('1000000000000000000')
 
 export const SECONDS_PER_YEAR = BigDecimal.fromString('31536000')
-
+export const T_TOKEN = '0xcdf7028ceab81fa0c6971208e83fa7872994bee5'
 export const RKP3R_TOKEN = '0xEdB67Ee1B171c4eC66E6c10EC43EDBbA20FaE8e9'
 export const RKP3R_ADDRESS = Address.fromString(RKP3R_TOKEN)
 export const CVX_TOKEN = '0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B'
@@ -69,9 +69,20 @@ FOREX_ORACLES.set(GBP_LP_TOKEN, Address.fromString('0x5c0Ab2d9b5a7ed9f470386e82B
 FOREX_ORACLES.set(AUD_LP_TOKEN, Address.fromString('0x77F9710E7d0A19669A13c055F62cd80d313dF022'))
 FOREX_ORACLES.set(CHF_LP_TOKEN, Address.fromString('0x449d117117838fFA61263B61dA6301AA2a88B13A'))
 
-// handle wrapped tokens and synths in v2 pools
-export const SYNTH_TOKENS = new Map<string, Address>()
-SYNTH_TOKENS.set(CVXFXS_TOKEN, Address.fromString(FXS_TOKEN))
+// handle tokens that only only trade on Curve
+// maps to other token on curve pool that can be priced elswhere
+// and token indice to know whether to invert price oracle or not
+class OracleInfo {
+  pricingToken: Address
+  tokenIndex: i32
+  constructor(pricingToken: Address, tokenIndex: i32) {
+    this.pricingToken = pricingToken
+    this.tokenIndex = tokenIndex
+  }
+}
+export const CURVE_ONLY_TOKENS = new Map<string, OracleInfo>()
+CURVE_ONLY_TOKENS.set(CVXFXS_TOKEN, new OracleInfo(Address.fromString(FXS_TOKEN), 1))
+CURVE_ONLY_TOKENS.set(T_TOKEN, new OracleInfo(WETH_ADDRESS, 1))
 
 export const SUSHISWAP_WETH_USDT_PAIR_ADDRESS = Address.fromString('0x06da0fd433c1a5d7a4faa01111c044910a184553')
 export const SUSHI_FACTORY_ADDRESS = Address.fromString('0xc0aee478e3658e2610c5f7a4a2e1777ce9e4f2ac')

--- a/subgraphs/curve-pools/abis/Booster.json
+++ b/subgraphs/curve-pools/abis/Booster.json
@@ -1,8 +1,16 @@
 [
   {
     "inputs": [
-      { "internalType": "address", "name": "_staker", "type": "address" },
-      { "internalType": "address", "name": "_minter", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_staker",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_minter",
+        "type": "address"
+      }
     ],
     "stateMutability": "nonpayable",
     "type": "constructor"
@@ -10,9 +18,24 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
-      { "indexed": true, "internalType": "uint256", "name": "poolid", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "poolid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
     ],
     "name": "Deposited",
     "type": "event"
@@ -20,9 +43,24 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
-      { "indexed": true, "internalType": "uint256", "name": "poolid", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "poolid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
     ],
     "name": "Withdrawn",
     "type": "event"
@@ -30,181 +68,395 @@
   {
     "inputs": [],
     "name": "FEE_DENOMINATOR",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "MaxFees",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_lptoken", "type": "address" },
-      { "internalType": "address", "name": "_gauge", "type": "address" },
-      { "internalType": "uint256", "name": "_stashVersion", "type": "uint256" }
+      {
+        "internalType": "address",
+        "name": "_lptoken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_gauge",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_stashVersion",
+        "type": "uint256"
+      }
     ],
     "name": "addPool",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
-      { "internalType": "address", "name": "_gauge", "type": "address" }
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_gauge",
+        "type": "address"
+      }
     ],
     "name": "claimRewards",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "crv",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-      { "internalType": "bool", "name": "_stake", "type": "bool" }
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_stake",
+        "type": "bool"
+      }
     ],
     "name": "deposit",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
-      { "internalType": "bool", "name": "_stake", "type": "bool" }
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_stake",
+        "type": "bool"
+      }
     ],
     "name": "depositAll",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "distributionAddressId",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "earmarkFees",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "earmarkIncentive",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "uint256", "name": "_pid", "type": "uint256" }],
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
     "name": "earmarkRewards",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "feeDistro",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "feeManager",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "feeToken",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "name": "gaugeMap",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "isShutdown",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "lockFees",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "lockIncentive",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "lockRewards",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "minter",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "owner",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "platformFee",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "name": "poolInfo",
     "outputs": [
-      { "internalType": "address", "name": "lptoken", "type": "address" },
-      { "internalType": "address", "name": "token", "type": "address" },
-      { "internalType": "address", "name": "gauge", "type": "address" },
-      { "internalType": "address", "name": "crvRewards", "type": "address" },
-      { "internalType": "address", "name": "stash", "type": "address" },
-      { "internalType": "bool", "name": "shutdown", "type": "bool" }
+      {
+        "internalType": "address",
+        "name": "lptoken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "gauge",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "crvRewards",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "stash",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "shutdown",
+        "type": "bool"
+      }
     ],
     "stateMutability": "view",
     "type": "function"
@@ -212,51 +464,105 @@
   {
     "inputs": [],
     "name": "poolLength",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "poolManager",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "registry",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "rewardArbitrator",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
-      { "internalType": "address", "name": "_address", "type": "address" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_address",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
     ],
     "name": "rewardClaimed",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "rewardFactory",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "address", "name": "_arb", "type": "address" }],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_arb",
+        "type": "address"
+      }
+    ],
     "name": "setArbitrator",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -264,18 +570,42 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_rfactory", "type": "address" },
-      { "internalType": "address", "name": "_sfactory", "type": "address" },
-      { "internalType": "address", "name": "_tfactory", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_rfactory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_sfactory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tfactory",
+        "type": "address"
+      }
     ],
     "name": "setFactories",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
-  { "inputs": [], "name": "setFeeInfo", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
   {
-    "inputs": [{ "internalType": "address", "name": "_feeM", "type": "address" }],
+    "inputs": [],
+    "name": "setFeeInfo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_feeM",
+        "type": "address"
+      }
+    ],
     "name": "setFeeManager",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -283,10 +613,26 @@
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_lockFees", "type": "uint256" },
-      { "internalType": "uint256", "name": "_stakerFees", "type": "uint256" },
-      { "internalType": "uint256", "name": "_callerFees", "type": "uint256" },
-      { "internalType": "uint256", "name": "_platform", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "_lockFees",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_stakerFees",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_callerFees",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_platform",
+        "type": "uint256"
+      }
     ],
     "name": "setFees",
     "outputs": [],
@@ -294,21 +640,45 @@
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "uint256", "name": "_pid", "type": "uint256" }],
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
     "name": "setGaugeRedirect",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "address", "name": "_owner", "type": "address" }],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
     "name": "setOwner",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "address", "name": "_poolM", "type": "address" }],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolM",
+        "type": "address"
+      }
+    ],
     "name": "setPoolManager",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -316,8 +686,16 @@
   },
   {
     "inputs": [
-      { "internalType": "address", "name": "_rewards", "type": "address" },
-      { "internalType": "address", "name": "_stakerRewards", "type": "address" }
+      {
+        "internalType": "address",
+        "name": "_rewards",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_stakerRewards",
+        "type": "address"
+      }
     ],
     "name": "setRewardContracts",
     "outputs": [],
@@ -325,136 +703,296 @@
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "address", "name": "_treasury", "type": "address" }],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_treasury",
+        "type": "address"
+      }
+    ],
     "name": "setTreasury",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "address", "name": "_voteDelegate", "type": "address" }],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_voteDelegate",
+        "type": "address"
+      }
+    ],
     "name": "setVoteDelegate",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "uint256", "name": "_pid", "type": "uint256" }],
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
     "name": "shutdownPool",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
-  { "inputs": [], "name": "shutdownSystem", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "shutdownSystem",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
   {
     "inputs": [],
     "name": "staker",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "stakerIncentive",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "stakerRewards",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "stashFactory",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "tokenFactory",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "treasury",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_voteId", "type": "uint256" },
-      { "internalType": "address", "name": "_votingAddress", "type": "address" },
-      { "internalType": "bool", "name": "_support", "type": "bool" }
+      {
+        "internalType": "uint256",
+        "name": "_voteId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_votingAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_support",
+        "type": "bool"
+      }
     ],
     "name": "vote",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "voteDelegate",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "address[]", "name": "_gauge", "type": "address[]" },
-      { "internalType": "uint256[]", "name": "_weight", "type": "uint256[]" }
+      {
+        "internalType": "address[]",
+        "name": "_gauge",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_weight",
+        "type": "uint256[]"
+      }
     ],
     "name": "voteGaugeWeight",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "voteOwnership",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "voteParameter",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
     ],
     "name": "withdraw",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "_pid", "type": "uint256" }],
-    "name": "withdrawAll",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "_pid", "type": "uint256" },
-      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
-      { "internalType": "address", "name": "_to", "type": "address" }
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      }
     ],
     "name": "withdrawTo",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   }

--- a/subgraphs/curve-pools/schema.graphql
+++ b/subgraphs/curve-pools/schema.graphql
@@ -135,6 +135,7 @@ type DailyPoolSnapshot @entity {
   extraRewardsApr: BigDecimal!
   baseApr: BigDecimal!
   timestamp: BigInt!
+  block: BigInt!
 }
 
 type PoolReward @entity {

--- a/subgraphs/curve-pools/src/mapping.ts
+++ b/subgraphs/curve-pools/src/mapping.ts
@@ -34,7 +34,7 @@ import { recordFeeRevenue, takeWeeklyRevenueSnapshot } from './services/revenue'
 import { PoolCrvRewards } from '../generated/templates'
 import { CurveToken } from '../generated/Booster/CurveToken'
 import { getUser } from './services/user'
-import { getDailyPoolSnapshot } from './services/snapshots'
+import { getDailyPoolSnapshot, takePoolSnapshots } from './services/snapshots'
 
 export function handleAddPool(call: AddPoolCall): void {
   const platform = getPlatform()
@@ -148,6 +148,9 @@ export function handleWithdrawn(event: WithdrawnEvent): void {
     return
   }
   pool.lpTokenBalance = pool.lpTokenBalance.minus(withdrawal.amount)
+  pool.save()
+  takePoolSnapshots(event.block.timestamp)
+
   const lpPrice = getLpTokenPriceUSD(pool)
   log.debug('LP Token price USD for pool {}: {}', [pool.name, lpPrice.toString()])
   pool.lpTokenUSDPrice = lpPrice

--- a/subgraphs/curve-pools/src/mapping.ts
+++ b/subgraphs/curve-pools/src/mapping.ts
@@ -35,6 +35,7 @@ import { PoolCrvRewards } from '../generated/templates'
 import { CurveToken } from '../generated/Booster/CurveToken'
 import { getUser } from './services/user'
 import { getDailyPoolSnapshot, takePoolSnapshots } from './services/snapshots'
+import { inferAssetType } from './services/utils'
 
 export function handleAddPool(call: AddPoolCall): void {
   const platform = getPlatform()
@@ -113,7 +114,7 @@ export function handleAddPool(call: AddPoolCall): void {
   getPoolCoins(pool)
   log.info('New pool added {} at block {}', [pool.name, call.block.number.toString()])
 
-  pool.assetType = ASSET_TYPES.has(swap.toHexString()) ? ASSET_TYPES.get(swap.toHexString()) : 0
+  pool.assetType = pool.isV2 ? 4 : inferAssetType(swap.toHexString(), pool.name)
   pool.gauge = call.inputs._gauge
   pool.stashVersion = call.inputs._stashVersion
   // Initialize minor version at -1

--- a/subgraphs/curve-pools/src/mapping.ts
+++ b/subgraphs/curve-pools/src/mapping.ts
@@ -152,21 +152,20 @@ export function handleWithdrawn(event: WithdrawnEvent): void {
   pool.save()
   takePoolSnapshots(event.block.timestamp, event.block.number)
 
-  const lpPrice = getLpTokenPriceUSD(pool)
-  log.debug('LP Token price USD for pool {}: {}', [pool.name, lpPrice.toString()])
-  pool.lpTokenUSDPrice = lpPrice
   const lpSupply = getLpTokenSupply(pool.lpToken)
   pool.curveTvlRatio =
     lpSupply == BIG_INT_ZERO ? BIG_DECIMAL_ONE : pool.lpTokenBalance.toBigDecimal().div(lpSupply.toBigDecimal())
-  pool.tvl = pool.lpTokenBalance.toBigDecimal().div(BIG_DECIMAL_1E18).times(lpPrice)
 
   const snapshot = getDailyPoolSnapshot(pool, event.block.timestamp, event.block.number)
+  pool.tvl = pool.lpTokenBalance.toBigDecimal().div(BIG_DECIMAL_1E18).times(snapshot.lpTokenUSDPrice)
 
   pool.baseApr = snapshot.baseApr
   snapshot.tvl = pool.tvl
   snapshot.withdrawalCount = snapshot.withdrawalCount.plus(BIG_INT_ONE)
   snapshot.withdrawalVolume = snapshot.withdrawalVolume.plus(event.params.amount)
-  snapshot.withdrawalValue = snapshot.withdrawalValue.plus(event.params.amount.toBigDecimal().times(lpPrice))
+  snapshot.withdrawalValue = snapshot.withdrawalValue.plus(
+    event.params.amount.toBigDecimal().times(snapshot.lpTokenUSDPrice)
+  )
 
   pool.save()
   snapshot.save()
@@ -188,21 +187,18 @@ export function handleDeposited(event: DepositedEvent): void {
   pool.save()
   takePoolSnapshots(event.block.timestamp, event.block.number)
 
-  const lpPrice = getLpTokenPriceUSD(pool)
-  log.debug('LP Token price USD for pool {}: {}', [pool.name, lpPrice.toString()])
-  pool.lpTokenUSDPrice = lpPrice
   const lpSupply = getLpTokenSupply(pool.lpToken)
   pool.curveTvlRatio =
     lpSupply == BIG_INT_ZERO ? BIG_DECIMAL_ONE : pool.lpTokenBalance.toBigDecimal().div(lpSupply.toBigDecimal())
-  pool.tvl = pool.lpTokenBalance.toBigDecimal().div(BIG_DECIMAL_1E18).times(lpPrice)
 
   const snapshot = getDailyPoolSnapshot(pool, event.block.timestamp, event.block.number)
+  pool.tvl = pool.lpTokenBalance.toBigDecimal().div(BIG_DECIMAL_1E18).times(snapshot.lpTokenUSDPrice)
 
   pool.baseApr = snapshot.baseApr
   snapshot.tvl = pool.tvl
   snapshot.depositCount = snapshot.depositCount.plus(BIG_INT_ONE)
   snapshot.depositVolume = snapshot.depositVolume.plus(event.params.amount)
-  snapshot.depositValue = snapshot.depositValue.plus(event.params.amount.toBigDecimal().times(lpPrice))
+  snapshot.depositValue = snapshot.depositValue.plus(event.params.amount.toBigDecimal().times(snapshot.lpTokenUSDPrice))
 
   pool.save()
   snapshot.save()

--- a/subgraphs/curve-pools/src/services/apr.ts
+++ b/subgraphs/curve-pools/src/services/apr.ts
@@ -20,6 +20,7 @@ import {
   EURS_ADDRESS,
   SYNTH_TOKENS,
   BIG_DECIMAL_TWO,
+  BIG_INT_ZERO,
 } from 'const'
 
 import { ERC20 } from '../../generated/Booster/ERC20'
@@ -143,7 +144,7 @@ export function getV2PoolBaseApr(
   currentXcpProfitA: BigDecimal,
   timestamp: BigInt
 ): BigDecimal {
-  const previousSnapshot = getDailyPoolSnapshot(pool, timestamp.minus(DAY))
+  const previousSnapshot = getDailyPoolSnapshot(pool, timestamp.minus(DAY), BIG_INT_ZERO)
   if (!previousSnapshot) {
     return BIG_DECIMAL_ZERO
   }
@@ -169,7 +170,7 @@ export function getV2PoolBaseApr(
 }
 
 export function getPoolBaseApr(pool: Pool, currentVirtualPrice: BigDecimal, timestamp: BigInt): BigDecimal {
-  const previousDaySnapshot = getDailyPoolSnapshot(pool, timestamp.minus(DAY))
+  const previousDaySnapshot = getDailyPoolSnapshot(pool, timestamp.minus(DAY), BIG_INT_ZERO)
   const previousDayVPrice = previousDaySnapshot.lpTokenVirtualPrice
   const baseApr =
     previousDayVPrice == BIG_DECIMAL_ZERO

--- a/subgraphs/curve-pools/src/services/snapshots.ts
+++ b/subgraphs/curve-pools/src/services/snapshots.ts
@@ -3,6 +3,7 @@ import { BigInt } from '@graphprotocol/graph-ts'
 import { getIntervalFromTimestamp, DAY } from '../../../../packages/utils/time'
 import { getPoolApr, getXcpProfitResult } from './pools'
 import { getLpTokenVirtualPrice, getPoolBaseApr, getV2PoolBaseApr } from './apr'
+import { getPlatform } from './platform'
 
 export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt): DailyPoolSnapshot {
   const time = getIntervalFromTimestamp(timestamp, DAY)
@@ -35,4 +36,14 @@ export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt): DailyPoolSn
     snapshot.save()
   }
   return snapshot
+}
+
+export function takePoolSnapshots(timestamp: BigInt): void {
+  const platform = getPlatform()
+  for (let i = 0; i < platform.poolCount.toI32(); ++i) {
+    const pool = Pool.load(i.toString())
+    if (pool && pool.active) {
+      getDailyPoolSnapshot(pool, timestamp)
+    }
+  }
 }

--- a/subgraphs/curve-pools/src/services/snapshots.ts
+++ b/subgraphs/curve-pools/src/services/snapshots.ts
@@ -5,7 +5,7 @@ import { getPoolApr, getXcpProfitResult } from './pools'
 import { getLpTokenVirtualPrice, getPoolBaseApr, getV2PoolBaseApr } from './apr'
 import { getPlatform } from './platform'
 
-export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt): DailyPoolSnapshot {
+export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt, block: BigInt): DailyPoolSnapshot {
   const time = getIntervalFromTimestamp(timestamp, DAY)
   const snapId = pool.name + '-' + pool.poolid.toString() + '-' + time.toString()
   let snapshot = DailyPoolSnapshot.load(snapId)
@@ -33,17 +33,18 @@ export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt): DailyPoolSn
     } else {
       snapshot.baseApr = getPoolBaseApr(pool, snapshot.lpTokenVirtualPrice, timestamp)
     }
+    snapshot.block = block
     snapshot.save()
   }
   return snapshot
 }
 
-export function takePoolSnapshots(timestamp: BigInt): void {
+export function takePoolSnapshots(timestamp: BigInt, block: BigInt): void {
   const platform = getPlatform()
   for (let i = 0; i < platform.poolCount.toI32(); ++i) {
     const pool = Pool.load(i.toString())
     if (pool && pool.active) {
-      getDailyPoolSnapshot(pool, timestamp)
+      getDailyPoolSnapshot(pool, timestamp, block)
     }
   }
 }

--- a/subgraphs/curve-pools/src/services/snapshots.ts
+++ b/subgraphs/curve-pools/src/services/snapshots.ts
@@ -10,6 +10,7 @@ export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt, block: BigIn
   const snapId = pool.name + '-' + pool.poolid.toString() + '-' + time.toString()
   let snapshot = DailyPoolSnapshot.load(snapId)
   if (!snapshot) {
+    log.info('Taking pool snapshot for pool {} ({}), block: {}', [pool.name, pool.swap.toHexString(), block.toString()])
     snapshot = new DailyPoolSnapshot(snapId)
     snapshot.poolid = pool.poolid.toString()
     snapshot.poolName = pool.name

--- a/subgraphs/curve-pools/src/services/snapshots.ts
+++ b/subgraphs/curve-pools/src/services/snapshots.ts
@@ -29,6 +29,7 @@ export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt, block: BigIn
     pool.crvApr = aprs[0]
     pool.cvxApr = aprs[1]
     pool.extraRewardsApr = aprs[2]
+    pool.save()
 
     snapshot.lpTokenBalance = pool.lpTokenBalance
     snapshot.curveTvlRatio = pool.curveTvlRatio

--- a/subgraphs/curve-pools/src/services/snapshots.ts
+++ b/subgraphs/curve-pools/src/services/snapshots.ts
@@ -1,8 +1,8 @@
 import { DailyPoolSnapshot, Pool } from '../../generated/schema'
-import { BigInt } from '@graphprotocol/graph-ts'
+import { BigInt, log } from '@graphprotocol/graph-ts'
 import { getIntervalFromTimestamp, DAY } from '../../../../packages/utils/time'
 import { getPoolApr, getXcpProfitResult } from './pools'
-import { getLpTokenVirtualPrice, getPoolBaseApr, getV2PoolBaseApr } from './apr'
+import { getLpTokenPriceUSD, getLpTokenVirtualPrice, getPoolBaseApr, getV2PoolBaseApr } from './apr'
 import { getPlatform } from './platform'
 
 export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt, block: BigInt): DailyPoolSnapshot {
@@ -14,15 +14,21 @@ export function getDailyPoolSnapshot(pool: Pool, timestamp: BigInt, block: BigIn
     snapshot.poolid = pool.poolid.toString()
     snapshot.poolName = pool.name
     snapshot.timestamp = timestamp
+    snapshot.lpTokenVirtualPrice = getLpTokenVirtualPrice(pool)
+
+    const lpPrice = getLpTokenPriceUSD(pool)
+    log.debug('LP Token price USD for pool {}: {}', [pool.name, lpPrice.toString()])
+    pool.lpTokenUSDPrice = lpPrice
+    snapshot.lpTokenUSDPrice = pool.lpTokenUSDPrice
+
     const aprs = getPoolApr(pool, timestamp)
+    snapshot.crvApr = aprs[0]
+    snapshot.cvxApr = aprs[1]
+    snapshot.extraRewardsApr = aprs[2]
     pool.crvApr = aprs[0]
     pool.cvxApr = aprs[1]
     pool.extraRewardsApr = aprs[2]
-    snapshot.lpTokenVirtualPrice = getLpTokenVirtualPrice(pool)
-    snapshot.lpTokenUSDPrice = pool.lpTokenUSDPrice
-    snapshot.crvApr = pool.crvApr
-    snapshot.cvxApr = pool.cvxApr
-    snapshot.extraRewardsApr = pool.extraRewardsApr
+
     snapshot.lpTokenBalance = pool.lpTokenBalance
     snapshot.curveTvlRatio = pool.curveTvlRatio
     if (pool.isV2) {

--- a/subgraphs/curve-pools/src/services/utils.ts
+++ b/subgraphs/curve-pools/src/services/utils.ts
@@ -1,0 +1,22 @@
+import { ASSET_TYPES } from 'const'
+
+export function inferAssetType(curvePool: string, poolName: string): i32 {
+  if (ASSET_TYPES.has(curvePool)) {
+    return ASSET_TYPES.get(curvePool)
+  }
+  const description = poolName.toUpperCase()
+  const stables = ['USD', 'DAI', 'MIM', 'TETHER']
+  for (let i = 0; i < stables.length; i++) {
+    if (description.indexOf(stables[i]) >= 0) {
+      return 0
+    }
+  }
+
+  if (description.indexOf('BTC') >= 0) {
+    return 2
+  } else if (description.indexOf('ETH') >= 0) {
+    return 1
+  } else {
+    return 3
+  }
+}

--- a/subgraphs/curve-pools/subgraph.yaml
+++ b/subgraphs/curve-pools/subgraph.yaml
@@ -23,7 +23,7 @@ dataSources:
         - Platform
       abis:
         - name: Booster
-          file: ./abis/Booster.json
+          file: ../../abis/Booster.json
         - name: CurveRegistry
           file: ../../abis/CurveRegistry.json
         - name: CurveToken

--- a/subgraphs/curve-pools/subgraph.yaml
+++ b/subgraphs/curve-pools/subgraph.yaml
@@ -94,4 +94,3 @@ templates:
         - function: queueNewRewards(uint256)
           handler: handleNewRewardsQueued
       file: ./src/mapping-rewards.ts
-


### PR DESCRIPTION
- Fix asset type detection (BTC/ETH pools were coming up as stable pools)
- Handle expired CRV/CVX rewards
- Refactor to calc LP price once per day
- Refactor to take all pool snapshots at the same time (to keep fresh snapshots of pools with no activity)
- Store block number in snapshots
- Better support for pricing assets only trading on Curve (still manual so not ideal)